### PR TITLE
Fixes for Hydrogen compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
+Will Whitney <wfwhitney@gmail.com>

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ Message.prototype.parse = function(requestArguments) {
 
     if (this.key === '') {
         // no key, messages aren't signed
-        this.signatureOK = (this.signature === '');
+        this.signatureOK = true;
     } else {
         this.signature = requestArguments[i + 1].toString();
         var hmac = crypto.createHmac(this.scheme, this.key);
@@ -155,7 +155,10 @@ Message.prototype.parse = function(requestArguments) {
         this.signatureOK = (this.signature === hmac.digest("hex"));
     }
 
-    if (!this.signatureOK) return;
+    if (!this.signatureOK) {
+        console.error("Incorrect message signature:", this.signature);
+        return;
+    }
 
     function toJSON(value) {
         return JSON.parse(value.toString());


### PR DESCRIPTION
- Added an error message if the signature is incorrect (previously it was just swallowed)
- Eliminated the signature check if key = ""
  - This was done before with `(this.signature === '')`, but it didn't actually work
