### PR TITLE
[Discuss] Rely on zmq-prebuilt

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@
 
 var crypto = require("crypto");
 var uuid = require("node-uuid");
-var zmq = require("zmq");
+var zmq = require("zmq-prebuilt");
 
 var DEBUG = global.DEBUG || false;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-uuid": "^1.4.2",
-        "zmq-prebuilt": "0.0.3"
+        "zmq-prebuilt": "^1.0.2"
     },
     "devDependencies": {
         "jsdoc": "latest",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-uuid": "^1.4.2",
-        "zmq": "^2.10.0"
+        "zmq-prebuilt": "0.0.3"
     },
     "devDependencies": {
         "jsdoc": "latest",


### PR DESCRIPTION
I'd like to start trying out the use of a prebuilt zmq with nteract and Hydrogen. It does make the Linux and Mac story easier for install. The Windows story is not complete, as far as I know.

I'm not expecting you to merge this, I'll probably create a jmp-prebuilt package that we can rely on in `enchannel-zmq-backend`.
