### PR TITLE
Upgrade to zmq-prebuilt 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-uuid": "^1.4.2",
-        "zmq-prebuilt": "^0.0.3"
+        "zmq-prebuilt": "^1.2.0"
     },
     "devDependencies": {
         "jsdoc": "latest",


### PR DESCRIPTION
New release, with Linux and OS X support.

/cc @captainsafia
