### PR TITLE
Upgrade to zmq-prebuilt 2.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@
 # Please keep the list sorted.
 
 Benjamin Abel <bbig26@gmail.com>
+Lukas Geiger <lukas.geiger94@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-uuid": "^1.4.2",
-        "zmq-prebuilt": "1.x"
+        "zmq-prebuilt": "2.x"
     },
     "devDependencies": {
         "jsdoc": "latest",


### PR DESCRIPTION
We have prebuilt binaries working for Linux, OS X and Windows.
`zmq-prebuilt` can now be built from source as well to support rebuilding with different electron versions. In other words the [fallback works](https://github.com/nteract/zmq-prebuilt/pull/57) 🎉.
