### PR TITLE
Upgrade zeromq

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@
 
 var crypto = require("crypto");
 var uuid = require("node-uuid");
-var zmq = require("zmq-prebuilt");
+var zmq = require("zeromq");
 
 var DEBUG = global.DEBUG || false;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-uuid": "^1.4.2",
-        "zmq-prebuilt": "2.x"
+        "zeromq": "3.x"
     },
     "devDependencies": {
         "debug": "2.x",


### PR DESCRIPTION
`zmq-prebuilt` has been renamed to [`zeromq`](https://github.com/zeromq/zeromq.js) and is now maintained inside the [zeromq organisation](https://github.com/zeromq/).
