### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ exports the module `zmq`:
 
 ```js
 var crypto = require("crypto");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var jmp = require("jmp");
 var zmq = jmp.zmq;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
  */
 
 var crypto = require("crypto");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 var zmq = require("zeromq");
 
 var DEBUG = global.DEBUG || false;

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-    "name": "jmp",
-    "version": "0.7.2",
-    "description": "Node.js module for creating, parsing and replying to messages of the Jupyter Messaging Protocol (JMP)",
-    "keywords": [
-        "jupyter",
-        "messaging",
-        "protocol",
-        "ijavascript"
-    ],
-    "bugs": {
-        "url": "https://github.com/n-riesco/jmp/issues"
-    },
-    "license": "BSD-3-Clause",
-    "author": {
-        "author": "Nicolas Riesco",
-        "email": "enquiries@nicolasriesco.net",
-        "url": "http://www.nicolasriesco.net/"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/n-riesco/jmp.git"
-    },
-    "dependencies": {
-        "node-uuid": "^1.3.0",
-        "zeromq": "^3.2.0"
-    },
-    "devDependencies": {
-        "debug": "2.x",
-        "jsdoc": "latest",
-        "jshint": "latest",
-        "mocha": "3.x"
-    },
-    "scripts": {
-        "doc": "jsdoc -R README.md -d doc index.js",
-        "doc:publish": "node scripts/doc-publish.js doc https://github.com/n-riesco/jmp",
-        "lint": "jshint index.js test/",
-        "test:mocha": "mocha",
-        "test": "npm run lint && npm run test:mocha"
-    }
+  "name": "jmp",
+  "version": "0.7.2",
+  "description": "Node.js module for creating, parsing and replying to messages of the Jupyter Messaging Protocol (JMP)",
+  "keywords": [
+    "jupyter",
+    "messaging",
+    "protocol",
+    "ijavascript"
+  ],
+  "bugs": {
+    "url": "https://github.com/n-riesco/jmp/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": {
+    "author": "Nicolas Riesco",
+    "email": "enquiries@nicolasriesco.net",
+    "url": "http://www.nicolasriesco.net/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/n-riesco/jmp.git"
+  },
+  "dependencies": {
+    "uuid": "^3.0.0",
+    "zeromq": "^3.2.0"
+  },
+  "devDependencies": {
+    "debug": "2.x",
+    "jsdoc": "latest",
+    "jshint": "latest",
+    "mocha": "3.x"
+  },
+  "scripts": {
+    "doc": "jsdoc -R README.md -d doc index.js",
+    "doc:publish": "node scripts/doc-publish.js doc https://github.com/n-riesco/jmp",
+    "lint": "jshint index.js test/",
+    "test:mocha": "mocha",
+    "test": "npm run lint && npm run test:mocha"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ var assert = require("assert");
 var crypto = require("crypto");
 var util = require("util");
 
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var jmp = require("..");
 var zmq = jmp.zmq;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.