### PR TITLE
Bump zeromq.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 os: linux
 language: node_js
 node_js:
-  - "0.10"
-  - "4"
   - "6"
   - "8"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "uuid": "3",
-        "zeromq": "4"
+        "zeromq": "5"
     },
     "devDependencies": {
         "debug": "2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
         "uuid": "3",
         "zeromq": "5"
     },
+    "engines": {
+        "node": ">=6.0"
+    },
     "devDependencies": {
         "debug": "2",
         "eslint": "2",


### PR DESCRIPTION
This features prebuilts for Electron 3 and Node 10

Node 4 support was dropped.